### PR TITLE
[WFLY-20485] Prepare the guide for integration in wildfly/wildfly docs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
 	</parent>
 
 	<groupId>org.wildfly</groupId>
-	<artifactId>docs-app-development-guide</artifactId>
-	<version>36.0.0.Final-SNAPSHOT</version>
+	<artifactId>wildfly-application-development-guide</artifactId>
+	<version>1.0.0.Final-SNAPSHOT</version>
 
 	<name>WildFly Application Development Guide</name>
 	<description>WildFly application development guide using Asciidoctor Maven plugin.</description>
@@ -41,11 +41,20 @@
 		<asciidoctor.maven.plugin.version>3.0.0</asciidoctor.maven.plugin.version>
 		<asciidoctorj.version>2.5.13</asciidoctorj.version>
 		<jruby.version>9.4.6.0</jruby.version>
+		<server.version>38.0.0.Final</server.version>
 		<plugin.version>5.1.1.Final</plugin.version>
+		<!-- skip the sources artifact, would be the same as jar artifact -->
+		<maven.source.skip>true</maven.source.skip>
 	</properties>
 
 	<build>
-		<defaultGoal>process-resources</defaultGoal>
+		<!-- include the resources in the jar, so we can build it elsewhere -->
+		<resources>
+			<resource>
+				<directory>${project.basedir}/src/docs/asciidoc</directory>
+			</resource>
+		</resources>
+		<!-- builds the doc, but the html file is not included in the jar -->
 		<plugins>
 			<plugin>
 				<groupId>org.asciidoctor</groupId>
@@ -68,17 +77,9 @@
 					</dependency>
 				</dependencies>
 				<configuration>
-					<sourceDirectory>src/docs/asciidoc</sourceDirectory>
-					<!-- If you set baseDir to ${project.basedir}, top-level
-					includes are resolved relative to the project root -->
-					<!--
-                    <baseDir>${project.basedir}</baseDir>
-                    -->
 					<!-- Attributes common to all output formats, and versions to be injected -->
 					<attributes>
-						<endpoint-url>https://example.org</endpoint-url>
-						<sourcedir>${project.build.sourceDirectory}</sourcedir>
-						<project-version>${project.version}</project-version>
+						<server-version>${server.version}</server-version>
 						<plugin-version>${plugin.version}</plugin-version>
 					</attributes>
 				</configuration>
@@ -90,7 +91,6 @@
 							<goal>process-asciidoc</goal>
 						</goals>
 						<configuration>
-							<outputDirectory>${project.build.outputDirectory}</outputDirectory>						
 							<backend>html5</backend>
 							<attributes>
 								<source-highlighter>rouge</source-highlighter>

--- a/src/docs/asciidoc/Application_Development_Guide.adoc
+++ b/src/docs/asciidoc/Application_Development_Guide.adoc
@@ -3,7 +3,7 @@ include::_app-dev-guide/attributes.adoc[]
 :toc:
 :numbered:
 :toclevels: 4
-:appication_development:
+:application_development:
 
 = {GettingStartedDevelopingApplications}
 

--- a/src/docs/asciidoc/_app-dev-guide/assemblies/modules/sources/properties-base.xml
+++ b/src/docs/asciidoc/_app-dev-guide/assemblies/modules/sources/properties-base.xml
@@ -2,5 +2,5 @@
         <!-- the Maven project should use the minimum Java SE version supported -->
         <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
-        <version.server>{wildflyversion}</version.server>
+        <version.server>{serverVersion}</version.server>
     </properties>

--- a/src/docs/asciidoc/_app-dev-guide/attributes.adoc
+++ b/src/docs/asciidoc/_app-dev-guide/attributes.adoc
@@ -4,7 +4,7 @@
 :JEEE: Jakarta EE
 :JEE: {JEEE}
 :GettingStartedDevelopingApplications: Developing applications for {ProductShortName}
-:wildflyversion: {project-version}
+:serverVersion: {server-version}
 :wildflyPluginVersion: {plugin-version}
 
 :productNameInMaven: wildfly
@@ -39,7 +39,6 @@
 
 //BOMs
 
-:JBossServerBOMVersion: {wildflyversion}
 :JBossGroupID: org.wildfly.bom
 :JBossBOMWithTools: wildfly-ee-with-tools
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/projects/WFLY/issues/WFLY-20485

This PR changes:

- the artifactId, to reset versioning, which will not be in sync with WildFly
- the jar now contains the sources, not the html, since we need to build when integrating (to receive the attributes values from wildfly)

Note: this is related to https://github.com/wildfly/wildfly/pull/19399 
